### PR TITLE
fix the initialization of static methods

### DIFF
--- a/src/pde/pde_fokkerplanck_RF1.hpp
+++ b/src/pde/pde_fokkerplanck_RF1.hpp
@@ -16,7 +16,11 @@ public:
       : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
                terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
                get_dt_, do_poisson_solve_, has_analytic_soln_)
-  {}
+  {
+    v_thermal = 1; // executed at runtime, can use std::sqrt and other such methods
+    nu_0 = electron_density * electron_density * electron_density * electron_density
+      * coulomb_logarithm / (2 * M_PI * electron_density * v_thermal * v_thermal * v_thermal);
+  }
 
 private:
   // these fields will be checked against provided functions to make sure
@@ -38,9 +42,8 @@ private:
   static P constexpr T_e = 1.0;
   static P constexpr m_e = 1.0;
   static P constexpr delta = 1.0e-6;  // regularization parameter for collision frequency
-  static P constexpr v_thermal = 1;
-  static P constexpr nu_0 = electron_density * electron_density * electron_density * electron_density
-    * coulomb_logarithm / (2 * M_PI * electron_density * v_thermal * v_thermal * v_thermal);
+  static P v_thermal;
+  static P nu_0;
   
   static P constexpr z_eff = 1.0;   //TODO get this formula
   static P constexpr F_e0 = 1.0;    // This is the value of f_e at v = 0
@@ -225,4 +228,11 @@ private:
     return std::pow(0.25, dim.get_level());
   }
 };
+
+template<typename P>
+P PDE_fokkerplanck_RF1<P>::v_thermal;
+
+template<typename P>
+P PDE_fokkerplanck_RF1<P>::nu_0;
+
 } // namespace asgard


### PR DESCRIPTION
Fixes the issue with the `static constexpr` initialization.

Right now, `v_thermal` and `nu_0` are initialized at runtime in the constructor of the class, which allows the use of non-constexpr methods such as `std::sqrt`

The solution of adding the out-of-line template definitions is odd. I blame it on some C++ idiosyncrasy that they haven't really addressed because people normally don't abuse the static methods the way that ASGarD does.

Any of the current `static constexpr` variable can be handled in this way and also modified at runtime without the need to recompile. If the change comes from outside of the class, the variables will have to be made `public` but that's an easy bridge to cross.