### PR TITLE
fix the initialization problem

### DIFF
--- a/src/pde.hpp
+++ b/src/pde.hpp
@@ -122,6 +122,7 @@ std::unique_ptr<PDE<P>> make_PDE(parser const &cli_input)
   case PDE_opts::collisional_landau_1x3v:
     return std::make_unique<PDE_collisional_landau_1x3v<P>>(cli_input);
   case PDE_opts::fokkerplanck_RF1:
+    PDE_fokkerplanck_RF1<P>::init(cli_input);
     return std::make_unique<PDE_fokkerplanck_RF1<P>>(cli_input);  
   default:
     std::cout << "Invalid pde choice" << std::endl;

--- a/src/pde/pde_fokkerplanck_RF1.hpp
+++ b/src/pde/pde_fokkerplanck_RF1.hpp
@@ -12,15 +12,22 @@ template<typename P>
 class PDE_fokkerplanck_RF1 : public PDE<P>
 {
 public:
-  PDE_fokkerplanck_RF1(parser const &cli_input)
-      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
-               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
-               get_dt_, do_poisson_solve_, has_analytic_soln_)
+  /*!
+   * Called before the constructor to initialize the static variables.
+   * This method could be adjusted to read the values from an file.
+   */
+  static void init(parser const &)
   {
     v_thermal = std::sqrt(2 * T_e / m_e); // executed at runtime, can use std::sqrt and other such methods
     nu_0 = electron_density * electron_density * electron_density * electron_density
       * coulomb_logarithm / (2 * M_PI * electron_density * v_thermal * v_thermal * v_thermal);
   }
+
+  PDE_fokkerplanck_RF1(parser const &cli_input)
+      : PDE<P>(cli_input, num_dims_, num_sources_, num_terms_, dimensions_,
+               terms_, sources_, exact_vector_funcs_, exact_scalar_func_,
+               get_dt_, do_poisson_solve_, has_analytic_soln_)
+  {}
 
 private:
   // these fields will be checked against provided functions to make sure


### PR DESCRIPTION
Fixing the fix. @stefan-schnake

Added a new method `init()` which is called immediately before the constructor. The method accepts command line options and (in the future) can be adjusted to read the input from a file.